### PR TITLE
JAXBContext creation speedup using cache.

### DIFF
--- a/chouette-exchange-neptune/src/main/java/fr/certu/chouette/exchange/xml/neptune/importer/producer/AbstractModelProducer.java
+++ b/chouette-exchange-neptune/src/main/java/fr/certu/chouette/exchange/xml/neptune/importer/producer/AbstractModelProducer.java
@@ -35,6 +35,8 @@ public abstract class AbstractModelProducer<T extends NeptuneIdentifiedObject, U
    public static final String COMMON_1 = "2-NEPTUNE-Common-1";
    public static final String COMMON_2 = "2-NEPTUNE-Common-2";
 
+   private static JAXBContextCache jaxbContextCache = new JAXBContextCache();
+
    public void populateFromCastorNeptune(T target, U source, ReportItem report)
    {
       // ObjectId : maybe null but not empty
@@ -107,7 +109,7 @@ public abstract class AbstractModelProducer<T extends NeptuneIdentifiedObject, U
       JAXBContext jc;
       try
       {
-         jc = JAXBContext.newInstance(name);
+         jc = jaxbContextCache.getContext(name);
          String text = marshal(jc, object);
          return text;
       } catch (Exception e)

--- a/chouette-exchange-neptune/src/main/java/fr/certu/chouette/exchange/xml/neptune/importer/producer/JAXBContextCache.java
+++ b/chouette-exchange-neptune/src/main/java/fr/certu/chouette/exchange/xml/neptune/importer/producer/JAXBContextCache.java
@@ -1,0 +1,26 @@
+package fr.certu.chouette.exchange.xml.neptune.importer.producer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+public class JAXBContextCache {
+
+   private Map<String, JAXBContext> jaxbContextCache = new HashMap<>();
+
+   public JAXBContextCache() {
+   }
+
+   public JAXBContext getContext(String contextPath) throws JAXBException {
+      synchronized (jaxbContextCache) {
+         JAXBContext ret = jaxbContextCache.get(contextPath);
+         if (ret == null) {
+            ret = JAXBContext.newInstance(contextPath);
+            jaxbContextCache.put(contextPath, ret);
+         }
+         return ret;
+      }
+   }
+}


### PR DESCRIPTION
During a Neptune to GTFS conversion, most of the time is spend creating a new JAXBContext instance when converting a new object. This PR optimize this by keeping a cache of created JAXBContext. Re-using JAXBContext is possible and [thread-safe](https://jaxb.java.net/guide/Performance_and_thread_safety.html).
