### PR TITLE
Commentaire annotation mapping inutile pour pouvoir compiler sur glassfish.

### DIFF
--- a/mobi.chouette.model/src/main/java/mobi/chouette/model/VehicleJourneyAtStop.java
+++ b/mobi.chouette.model/src/main/java/mobi/chouette/model/VehicleJourneyAtStop.java
@@ -1,28 +1,15 @@
 package mobi.chouette.model;
 
-import java.sql.Time;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-import javax.persistence.Transient;
-import javax.persistence.UniqueConstraint;
-
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import mobi.chouette.model.type.BoardingAlightingPossibilityEnum;
-
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
+
+import javax.persistence.*;
+import java.sql.Time;
 
 /**
  * Chouette VehicleJourneyAtStop : passing time on stops
@@ -74,7 +61,7 @@ public class VehicleJourneyAtStop extends NeptuneObject {
 	 */
 	@Getter
 	@Setter
-	@Enumerated(EnumType.STRING)
+//	@Enumerated(EnumType.STRING)
 	@Transient
 //	@Column(name = "boarding_alighting_possibility")
 	private BoardingAlightingPossibilityEnum boardingAlightingPossibility;


### PR DESCRIPTION
J'utilise le module "mobi.chouette.model" sur un environnement Glassfish avec HIbernate.

Le mapping JPA `@Column` du champ `VehicleJourneyAtStop#boardingAlightingPossibility` a été commenté (temporairement j'imagine). Il reste toutefois l'annotation `@Enumerated`, qui pose problème sur mon serveur d'IC lorsque je compile ça avec le jar glassfish-embedded-all. Ce jar embarque lui-même Eclipse Link, qui lance sa validation des fichiers JPA et qui finit par le message d'erreur suivant : 

```
Error:java: java.lang.RuntimeException: Exception [EclipseLink-7153] (Eclipse Persistence Services - 2.5.2.v20140319-9ad6abd): org.eclipse.persistence.exceptions.ValidationException
Exception Description: Mapping annotations cannot be applied to fields or properties that have a @Transient specified. [field boardingAlightingPossibility] is in violation of this restriction.
```

Est-il possible de commenter le `Enumerated` le temps que le mapping JPA soit rétabli ?

Merci d'avance.
