### PR TITLE
Mise en commentaire annotation mapping JPA inutile

### DIFF
--- a/mobi.chouette.model/src/main/java/mobi/chouette/model/VehicleJourneyAtStop.java
+++ b/mobi.chouette.model/src/main/java/mobi/chouette/model/VehicleJourneyAtStop.java
@@ -74,7 +74,7 @@ public class VehicleJourneyAtStop extends NeptuneObject {
 	 */
 	@Getter
 	@Setter
-	@Enumerated(EnumType.STRING)
+//	@Enumerated(EnumType.STRING)
 	@Transient
 //	@Column(name = "boarding_alighting_possibility")
 	private BoardingAlightingPossibilityEnum boardingAlightingPossibility;


### PR DESCRIPTION
J'utilise le module "mobi.chouette.model" sur un environnement Glassfish avec HIbernate.

Le mapping JPA `@Column` du champ `VehicleJourneyAtStop#boardingAlightingPossibility` a été commenté (temporairement j'imagine). Il reste toutefois l'annotation `@Enumerated`, qui pose problème sur mon serveur d'IC lorsque je compile ça avec le jar glassfish-embedded-all. Ce jar embarque lui-même Eclipse Link, qui lance sa validation des fichiers JPA et qui finit par le message d'erreur suivant : 

```
Error:java: java.lang.RuntimeException: Exception [EclipseLink-7153] (Eclipse Persistence Services - 2.5.2.v20140319-9ad6abd): org.eclipse.persistence.exceptions.ValidationException
Exception Description: Mapping annotations cannot be applied to fields or properties that have a @Transient specified. [field boardingAlightingPossibility] is in violation of this restriction.
```

Est-il possible de commenter le `Enumerated` le temps que le mapping JPA soit rétabli ?

Merci d'avance.
