### PR TITLE
Error when checking if vehicleJourney already linked to timetable

### DIFF
--- a/mobi.chouette.model/src/main/java/mobi/chouette/model/Timetable.java
+++ b/mobi.chouette.model/src/main/java/mobi/chouette/model/Timetable.java
@@ -292,7 +292,7 @@ public class Timetable extends NeptuneIdentifiedObject {
 		if (!getVehicleJourneys().contains(vehicleJourney)) {
 			getVehicleJourneys().add(vehicleJourney);
 		}
-		if (!vehicleJourney.getTimetables().contains(vehicleJourney)) {
+		if (!vehicleJourney.getTimetables().contains(this)) {
 			vehicleJourney.getTimetables().add(this);
 		}
 	}


### PR DESCRIPTION
comparing agains `vehicleJourney` instead of `this` when adding a vehicleJourney to a timetable.

Issue is also present in the master, but I'm using this branch right now.
