### PR TITLE
GTFS Export: Do not simply reuse previous StopPoint boarding/alighting 

### DIFF
--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsTripProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsTripProducer.java
@@ -181,9 +181,14 @@ public class GtfsTripProducer extends AbstractProducer {
 	}
 
 	private DropOffType toDropOffType(AlightingPossibilityEnum forAlighting, DropOffType defaultValue) {
+		if(forAlighting == null) {
+			// If not set on StopPoint return defaultValue (that is, the previous value) or if not set; Scheduled
+			return defaultValue == null ? DropOffType.Scheduled : defaultValue;
+		}
+		
 		switch (forAlighting) {
 		case normal:
-			return defaultValue == null ? DropOffType.Scheduled : defaultValue;
+			return DropOffType.Scheduled;
 		case forbidden:
 			return DropOffType.NoAvailable;
 		case is_flexible:
@@ -195,9 +200,14 @@ public class GtfsTripProducer extends AbstractProducer {
 	}
 
 	private PickupType toPickUpType(BoardingPossibilityEnum forBoarding, PickupType defaultValue) {
+		if(forBoarding == null) {
+			// If not set on StopPoint return defaultValue (that is, the previous value) or if not set; Scheduled
+			return defaultValue == null ? PickupType.Scheduled : defaultValue;
+		}
+		
 		switch (forBoarding) {
 		case normal:
-			return defaultValue == null ? PickupType.Scheduled : defaultValue;
+			return PickupType.Scheduled;
 		case forbidden:
 			return PickupType.NoAvailable;
 		case is_flexible:


### PR DESCRIPTION
In the current export, if the first stopPoint has boarding and alighting other than normal, the first value will be used as default value even if boarding/alighting "normal" is set on the next stoppoint.

Example: At the first StopPoint, there is no Alighting. If explicitly set, this value is reused for all StopPoint's forAlighting throughout the VehicleJourney, even if explicitly set to "normal" in Chouette.

The PR fixes this.
