### PR TITLE
Use VehicleJourney publishedJourneyName as trip_headsign when available

### DIFF
--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsTripProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsTripProducer.java
@@ -253,7 +253,9 @@ public class GtfsTripProducer extends AbstractProducer {
 		else
 			trip.setTripShortName(null);
 
-		if (!isEmpty(jp.getPublishedName()))
+		if (!isEmpty(vj.getPublishedJourneyName()))
+			trip.setTripHeadSign(vj.getPublishedJourneyName());
+		else if (!isEmpty(jp.getPublishedName()))
 			trip.setTripHeadSign(jp.getPublishedName());
 		else
 			trip.setTripHeadSign(null);


### PR DESCRIPTION
Currently JourneyPattern.publishedName is used as trips.txt -> trip_headsign. Since VehicleJourney is similar to a GTFS trip, VehicleJourney.publishedJourneyName should be preferred over JourneyPattern.publishedName.

The PR now uses VehicleJourney.publishedJourneyName as preferred trip_headsign, but falls back to JourneyPattern.publishedName when empty.
