### PR TITLE
Truncate all tables when cleaning before import

### DIFF
--- a/mobi.chouette.exchange/src/main/java/mobi/chouette/exchange/importer/CleanRepositoryCommand.java
+++ b/mobi.chouette.exchange/src/main/java/mobi/chouette/exchange/importer/CleanRepositoryCommand.java
@@ -9,21 +9,31 @@ import javax.ejb.TransactionAttributeType;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
+import com.jamonapi.Monitor;
+import com.jamonapi.MonitorFactory;
+
 import lombok.extern.log4j.Log4j;
 import mobi.chouette.common.Color;
 import mobi.chouette.common.Context;
 import mobi.chouette.common.chain.Command;
 import mobi.chouette.common.chain.CommandFactory;
+import mobi.chouette.dao.AccessLinkDAO;
+import mobi.chouette.dao.AccessPointDAO;
 import mobi.chouette.dao.CompanyDAO;
+import mobi.chouette.dao.ConnectionLinkDAO;
 import mobi.chouette.dao.GroupOfLineDAO;
+import mobi.chouette.dao.JourneyFrequencyDAO;
+import mobi.chouette.dao.JourneyPatternDAO;
 import mobi.chouette.dao.LineDAO;
 import mobi.chouette.dao.NetworkDAO;
+import mobi.chouette.dao.RouteDAO;
 import mobi.chouette.dao.RouteSectionDAO;
 import mobi.chouette.dao.StopAreaDAO;
+import mobi.chouette.dao.StopPointDAO;
+import mobi.chouette.dao.TimebandDAO;
 import mobi.chouette.dao.TimetableDAO;
-
-import com.jamonapi.Monitor;
-import com.jamonapi.MonitorFactory;
+import mobi.chouette.dao.VehicleJourneyAtStopDAO;
+import mobi.chouette.dao.VehicleJourneyDAO;
 
 @Log4j
 @Stateless(name = CleanRepositoryCommand.COMMAND)
@@ -31,27 +41,57 @@ public class CleanRepositoryCommand implements Command {
 
 	public static final String COMMAND = "CleanRepositoryCommand";
 
-	@EJB 
+	@EJB
+	private AccessLinkDAO accessLinkDAO;
+
+	@EJB
+	private AccessPointDAO accessPointDAO;
+
+	@EJB
+	private CompanyDAO companyDAO;
+
+	@EJB
+	private ConnectionLinkDAO connectionLinkDAO;
+
+	@EJB
+	private GroupOfLineDAO groupOfLineDAO;
+
+	@EJB
+	private JourneyFrequencyDAO journeyFrequencyDAO;
+
+	@EJB
+	private JourneyPatternDAO journeyPatternDAO;
+
+	@EJB
 	private LineDAO lineDAO;
 
-	@EJB 
+	@EJB
 	private NetworkDAO networkDAO;
-	
-	@EJB 
-	private StopAreaDAO stopAreaDAO;
 
-	@EJB 
+	@EJB
+	private RouteDAO routeDAO;
+
+	@EJB
 	private RouteSectionDAO routeSectionDAO;
 
-	@EJB 
-	private CompanyDAO companyDAO;
-	
-	@EJB 
+	@EJB
+	private StopAreaDAO stopAreaDAO;
+
+	@EJB
+	private StopPointDAO stopPointDAO;
+
+	@EJB
 	private TimetableDAO timetableDAO;
-	
-	@EJB 
-	private GroupOfLineDAO groupOfLineDAO;
-	
+
+	@EJB
+	private TimebandDAO timebandDAO;
+
+	@EJB
+	private VehicleJourneyDAO vehicleJourneyDAO;
+
+	@EJB
+	private VehicleJourneyAtStopDAO vehicleJourneyAtStopDAO;
+
 	@Override
 	@TransactionAttribute(TransactionAttributeType.REQUIRES_NEW)
 	public boolean execute(Context context) throws Exception {
@@ -60,13 +100,24 @@ public class CleanRepositoryCommand implements Command {
 		Monitor monitor = MonitorFactory.start(COMMAND);
 
 		try {
-			lineDAO.truncate();
+
+			accessLinkDAO.truncate();
+			accessPointDAO.truncate();
 			companyDAO.truncate();
+			connectionLinkDAO.truncate();
+			groupOfLineDAO.truncate();
+			journeyFrequencyDAO.truncate();
+			journeyPatternDAO.truncate();
+			lineDAO.truncate();
 			networkDAO.truncate();
+			routeDAO.truncate();
 			routeSectionDAO.truncate();
 			stopAreaDAO.truncate();
+			stopPointDAO.truncate();
 			timetableDAO.truncate();
-			groupOfLineDAO.truncate();
+			timebandDAO.truncate();
+			vehicleJourneyDAO.truncate();
+			vehicleJourneyAtStopDAO.truncate();
 
 			result = SUCCESS;
 		} catch (Exception e) {
@@ -76,7 +127,6 @@ public class CleanRepositoryCommand implements Command {
 		log.info(Color.MAGENTA + monitor.stop() + Color.NORMAL);
 		return result;
 	}
-
 
 	public static class DefaultCommandFactory extends CommandFactory {
 
@@ -100,7 +150,6 @@ public class CleanRepositoryCommand implements Command {
 	}
 
 	static {
-		CommandFactory.factories.put(CleanRepositoryCommand.class.getName(),
-				new DefaultCommandFactory());
+		CommandFactory.factories.put(CleanRepositoryCommand.class.getName(), new DefaultCommandFactory());
 	}
 }


### PR DESCRIPTION
Currently if the data in the dataspace are invalid, cleaning will not work properly and leave data behind in tables.

This patch ensures that all tables are cleaned (TRUNCATED).
