### PR TITLE
Add GTFS export parameter to keep objectId from Chouette on export

### DIFF
--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/GtfsExportParameters.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/GtfsExportParameters.java
@@ -30,6 +30,10 @@ public class GtfsExportParameters  extends AbstractExportParameter {
 	@XmlElement(name = "object_id_prefix",required = true)
 	private String objectIdPrefix;
 	
+	@Getter @Setter
+	@XmlElement(name = "keep_original_id",required = false, defaultValue = "false")
+	private boolean keepOriginalId;
+	
 	public boolean isValid(Logger log, String[] allowedTypes)
 	{
 		if (!super.isValid(log,allowedTypes)) return false;

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/GtfsExportParameters.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/GtfsExportParameters.java
@@ -18,7 +18,7 @@ import org.apache.log4j.Logger;
 @NoArgsConstructor
 @ToString(callSuper=true)
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder={"objectIdPrefix","timeZone"})
+@XmlType(propOrder={"objectIdPrefix","timeZone","keepOriginalId"})
 
 public class GtfsExportParameters  extends AbstractExportParameter {
 		
@@ -31,8 +31,8 @@ public class GtfsExportParameters  extends AbstractExportParameter {
 	private String objectIdPrefix;
 	
 	@Getter @Setter
-	@XmlElement(name = "keep_original_id",required = false, defaultValue = "false")
-	private boolean keepOriginalId;
+	@XmlElement(name = "keep_original_id",required = false)
+	private boolean keepOriginalId = false;
 	
 	public boolean isValid(Logger log, String[] allowedTypes)
 	{

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/GtfsLineProducerCommand.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/GtfsLineProducerCommand.java
@@ -137,9 +137,9 @@ public class GtfsLineProducerCommand implements Command, Constant {
 		// utiliser la collection
 		if (!collection.getVehicleJourneys().isEmpty()) {
 			for (VehicleJourney vj : collection.getVehicleJourneys()) {
-				String tmKey = calendarProducer.key(vj.getTimetables(), sharedPrefix);
+				String tmKey = calendarProducer.key(vj.getTimetables(), sharedPrefix, configuration.isKeepOriginalId());
 				if (tmKey != null) {
-					if (tripProducer.save(vj, tmKey, prefix, sharedPrefix)) {
+					if (tripProducer.save(vj, tmKey, prefix, sharedPrefix, configuration.isKeepOriginalId())) {
 						hasVj = true;
 						jps.add(vj.getJourneyPattern());
 						if (!timetables.containsKey(tmKey)) {
@@ -149,10 +149,10 @@ public class GtfsLineProducerCommand implements Command, Constant {
 				}
 			} // vj loop
 			for (JourneyPattern jp : jps) {
-				shapeProducer.save(jp, prefix);
+				shapeProducer.save(jp, prefix, configuration.isKeepOriginalId());
 			}
 			if (hasVj) {
-				routeProducer.save(line, prefix);
+				routeProducer.save(line, prefix, configuration.isKeepOriginalId());
 				hasLine = true;
 				if (metadata != null) {
 					metadata.getResources().add(

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/GtfsSharedDataProducerCommand.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/GtfsSharedDataProducerCommand.java
@@ -115,7 +115,7 @@ public class GtfsSharedDataProducerCommand implements Command, Constant {
 
 		for (Iterator<StopArea> iterator = commercialStops.iterator(); iterator.hasNext();) {
 			StopArea stop = iterator.next();
-			if (!stopProducer.save(stop, sharedPrefix, null)) {
+			if (!stopProducer.save(stop, sharedPrefix, null, configuration.isKeepOriginalId())) {
 				iterator.remove();
 			} else {
 				if (metadata != null && stop.hasCoordinates())
@@ -124,7 +124,7 @@ public class GtfsSharedDataProducerCommand implements Command, Constant {
 			}
 		}
 		for (StopArea stop : physicalStops) {
-			stopProducer.save(stop, sharedPrefix, commercialStops);
+			stopProducer.save(stop, sharedPrefix, commercialStops, configuration.isKeepOriginalId());
 			if (metadata != null && stop.hasCoordinates())
 				metadata.getSpatialCoverage().update(stop.getLongitude().doubleValue(),
 						stop.getLatitude().doubleValue());
@@ -136,15 +136,15 @@ public class GtfsSharedDataProducerCommand implements Command, Constant {
 			} else if (!physicalStops.contains(link.getEndOfLink()) && !commercialStops.contains(link.getEndOfLink())) {
 				continue;
 			}
-			transferProducer.save(link, sharedPrefix);
+			transferProducer.save(link, sharedPrefix, configuration.isKeepOriginalId());
 		}
 
 		for (Company company : companies) {
-			agencyProducer.save(company, prefix, timezone);
+			agencyProducer.save(company, prefix, timezone, configuration.isKeepOriginalId());
 		}
 
 		for (List<Timetable> tms : timetables.values()) {
-			calendarProducer.save(tms, sharedPrefix);
+			calendarProducer.save(tms, sharedPrefix, configuration.isKeepOriginalId());
 			if (metadata != null) {
 				for (Timetable tm : tms) {
 					metadata.getTemporalCoverage().update(tm.getStartOfPeriod(), tm.getEndOfPeriod());

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/GtfsStopAreaProducerCommand.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/GtfsStopAreaProducerCommand.java
@@ -123,7 +123,7 @@ public class GtfsStopAreaProducerCommand implements Command, Constant {
 		}
 		for (Iterator<StopArea> iterator = commercialStops.iterator(); iterator.hasNext();) {
 			StopArea stop = iterator.next();
-			if (!stopProducer.save(stop, sharedPrefix, null)) {
+			if (!stopProducer.save(stop, sharedPrefix, null, configuration.isKeepOriginalId())) {
 				iterator.remove();
 			} else {
 				stopCount++;
@@ -133,7 +133,7 @@ public class GtfsStopAreaProducerCommand implements Command, Constant {
 			}
 		}
 		for (StopArea stop : physicalStops) {
-			stopProducer.save(stop, sharedPrefix, commercialStops);
+			stopProducer.save(stop, sharedPrefix, commercialStops, configuration.isKeepOriginalId());
 			stopCount++;
 			// if (stop.hasCoordinates())
 			// metadata.getSpatialCoverage().update(stop.getLongitude().doubleValue(),
@@ -147,7 +147,7 @@ public class GtfsStopAreaProducerCommand implements Command, Constant {
 			} else if (!physicalStops.contains(link.getEndOfLink()) && !commercialStops.contains(link.getEndOfLink())) {
 				continue;
 			}
-			transferProducer.save(link, sharedPrefix);
+			transferProducer.save(link, sharedPrefix, configuration.isKeepOriginalId());
 			connectionLinkCount++;
 		}
 		reporter.addObjectReport(context, "merged", OBJECT_TYPE.CONNECTION_LINK, "connection links", OBJECT_STATE.OK,

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/AbstractProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/AbstractProducer.java
@@ -22,7 +22,7 @@ public abstract class AbstractProducer
    static protected String toGtfsId(String neptuneId, String prefix, boolean keepOriginal)
    {
       if(keepOriginal) {
-    	  return neptuneId;
+    	  return neptuneId.replace(':', '.');
       } else {
     	  String[] tokens = neptuneId.split(":");
 	      if (tokens[0].equals(prefix))

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/AbstractProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/AbstractProducer.java
@@ -19,13 +19,17 @@ public abstract class AbstractProducer
       this.exporter = exporter;
    }
 
-   static protected String toGtfsId(String neptuneId, String prefix)
+   static protected String toGtfsId(String neptuneId, String prefix, boolean keepOriginal)
    {
-      String[] tokens = neptuneId.split(":");
-      if (tokens[0].equals(prefix))
-         return tokens[2];
-      else
-         return tokens[0] + "." + tokens[2];
+      if(keepOriginal) {
+    	  return neptuneId;
+      } else {
+    	  String[] tokens = neptuneId.split(":");
+	      if (tokens[0].equals(prefix))
+	         return tokens[2];
+	      else
+	         return tokens[0] + "." + tokens[2];
+	      }
    }
 
    static protected boolean isEmpty(String s)

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsAgencyProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsAgencyProducer.java
@@ -33,9 +33,9 @@ public class GtfsAgencyProducer extends AbstractProducer
    private GtfsAgency agency = new GtfsAgency();
 
 
-   public boolean save(Company neptuneObject, String prefix, TimeZone timeZone)
+   public boolean save(Company neptuneObject, String prefix, TimeZone timeZone, boolean keepOriginalId)
    {
-      agency.setAgencyId(toGtfsId(neptuneObject.getObjectId(),prefix));
+      agency.setAgencyId(toGtfsId(neptuneObject.getObjectId(),prefix,keepOriginalId));
 
       String name = neptuneObject.getName();
       if (name.trim().isEmpty())

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExtendedStopProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExtendedStopProducer.java
@@ -32,7 +32,7 @@ public class GtfsExtendedStopProducer extends
       super(exporter);
    }
 
-   public boolean save(StopArea neptuneObject,  String prefix, Collection<StopArea> validParents)
+   public boolean save(StopArea neptuneObject,  String prefix, Collection<StopArea> validParents, boolean keepOriginalId)
    {
       ChouetteAreaEnum chouetteAreaType = neptuneObject.getAreaType();
       if (chouetteAreaType.compareTo(ChouetteAreaEnum.BoardingPosition) == 0)
@@ -45,7 +45,7 @@ public class GtfsExtendedStopProducer extends
       // stop.setLocationType(GtfsStop.STATION);
       else
          return false; // StopPlaces and ITL type not available
-      stop.setStopId(toGtfsId(neptuneObject.getObjectId(),prefix));
+      stop.setStopId(toGtfsId(neptuneObject.getObjectId(),prefix,keepOriginalId));
       if (neptuneObject.getName() == null)
       {
 //         GtfsReportItem item = new GtfsReportItem(
@@ -96,7 +96,7 @@ public class GtfsExtendedStopProducer extends
          if (neptuneObject.getParent() != null && validParents.contains(neptuneObject.getParent()))
          {
             stop.setParentStation(toGtfsId(neptuneObject.getParent()
-                  .getObjectId(),prefix));
+                  .getObjectId(),prefix,keepOriginalId));
          }
       }
       

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsRouteProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsRouteProducer.java
@@ -29,10 +29,10 @@ public class GtfsRouteProducer extends AbstractProducer
 
    private GtfsRoute route = new GtfsRoute();
 
-   public boolean save(Line neptuneObject,  String prefix)
+   public boolean save(Line neptuneObject,  String prefix,boolean keepOriginalId)
    {
-      route.setRouteId(toGtfsId(neptuneObject.getObjectId(), prefix));
-      route.setAgencyId(toGtfsId(neptuneObject.getCompany().getObjectId(), prefix));
+      route.setRouteId(toGtfsId(neptuneObject.getObjectId(), prefix,keepOriginalId));
+      route.setAgencyId(toGtfsId(neptuneObject.getCompany().getObjectId(), prefix, keepOriginalId));
       route.setRouteShortName(null);
       route.setRouteLongName(null);
       if (isEmpty(neptuneObject.getNumber()))

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsServiceProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsServiceProducer.java
@@ -44,14 +44,14 @@ AbstractProducer
    GtfsCalendar calendar = new GtfsCalendar();
    GtfsCalendarDate calendarDate = new GtfsCalendarDate();
 
-   public boolean save(List<Timetable> timetables,  String prefix)
+   public boolean save(List<Timetable> timetables,  String prefix, boolean keepOriginalId)
    {
 
-      Timetable reduced = merge(timetables, prefix);
+      Timetable reduced = merge(timetables, prefix,keepOriginalId);
 
       if (reduced == null) return false;
 
-      String serviceId = toGtfsId(reduced.getObjectId(), prefix);
+      String serviceId = toGtfsId(reduced.getObjectId(), prefix, keepOriginalId);
 
       if (!isEmpty(reduced.getPeriods()))
       {
@@ -249,7 +249,7 @@ AbstractProducer
    }
 
 
-   private Timetable merge(List<Timetable> timetables,String prefix)
+   private Timetable merge(List<Timetable> timetables,String prefix, boolean keepOriginalId)
    {
       Timetable merged = reduce(timetables.get(0));
       if (timetables.size() > 1)
@@ -263,7 +263,7 @@ AbstractProducer
 			}
             
          }
-         merged.setObjectId(prefix+":"+Timetable.TIMETABLE_KEY+":"+key(timetables,prefix));
+         merged.setObjectId(prefix+":"+Timetable.TIMETABLE_KEY+":"+key(timetables,prefix,keepOriginalId));
       }
       merged.computeLimitOfPeriods();
       return merged;
@@ -276,7 +276,7 @@ AbstractProducer
       return !timetable.getPeriods().isEmpty() || !timetable.getCalendarDays().isEmpty();
    }
 
-   public String key(List<Timetable> timetables,String prefix)
+   public String key(List<Timetable> timetables,String prefix, boolean keepOriginalId)
    {
       if (isEmpty(timetables)) return null;
       // remove invalid timetables (no date set) 
@@ -291,7 +291,7 @@ AbstractProducer
       String key = "";
       for (Timetable timetable : timetables)
       {
-         key += "-"+toGtfsId(timetable.getObjectId(), prefix);
+         key += "-"+toGtfsId(timetable.getObjectId(), prefix, keepOriginalId);
       }
       return key.substring(1);
    }

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsServiceProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsServiceProducer.java
@@ -263,7 +263,7 @@ AbstractProducer
 			}
             
          }
-         merged.setObjectId(prefix+":"+Timetable.TIMETABLE_KEY+":"+key(timetables,prefix,keepOriginalId));
+         merged.setObjectId(prefix+":"+Timetable.TIMETABLE_KEY+":"+key(timetables,prefix,false));
       }
       merged.computeLimitOfPeriods();
       return merged;

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsShapeProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsShapeProducer.java
@@ -37,7 +37,7 @@ public class GtfsShapeProducer extends AbstractProducer
 
    private GtfsShape shape = new GtfsShape();
 
-   public boolean save(JourneyPattern neptuneObject,  String prefix)
+   public boolean save(JourneyPattern neptuneObject,  String prefix, boolean keepOriginalId)
    {
 	   boolean result = true;
 	   if (neptuneObject.getSectionStatus() != SectionStatusEnum.Completed)
@@ -47,7 +47,7 @@ public class GtfsShapeProducer extends AbstractProducer
 	   float distance = (float) 0.0;
 
 	   for (RouteSection rs : neptuneObject.getRouteSections() ) {
-		   shape.setShapeId(toGtfsId(neptuneObject.getObjectId(), prefix));
+		   shape.setShapeId(toGtfsId(neptuneObject.getObjectId(), prefix, keepOriginalId));
 		   if (rs == null)
 		   {
 		      continue;

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsStopProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsStopProducer.java
@@ -32,7 +32,7 @@ public class GtfsStopProducer extends AbstractProducer
 		super(exporter);
 	}
 
-	public boolean save(StopArea neptuneObject, String prefix, Collection<StopArea> validParents)
+	public boolean save(StopArea neptuneObject, String prefix, Collection<StopArea> validParents, boolean keepOriginalId)
 	{
 		ChouetteAreaEnum chouetteAreaType = neptuneObject.getAreaType();
 		if (chouetteAreaType.compareTo(ChouetteAreaEnum.BoardingPosition) == 0)
@@ -45,7 +45,7 @@ public class GtfsStopProducer extends AbstractProducer
 		// stop.setLocationType(GtfsStop.STATION);
 		else
 			return false; // StopPlaces and ITL type not available
-		stop.setStopId(toGtfsId(neptuneObject.getObjectId(),prefix));
+		stop.setStopId(toGtfsId(neptuneObject.getObjectId(),prefix, keepOriginalId));
 		if (neptuneObject.getName() == null)
 		{
 			//         GtfsReportItem item = new GtfsReportItem(
@@ -103,7 +103,7 @@ public class GtfsStopProducer extends AbstractProducer
 			if (neptuneObject.getParent() != null && validParents.contains(neptuneObject.getParent()))
 			{
 				stop.setParentStation(toGtfsId(neptuneObject.getParent()
-						.getObjectId(),prefix));
+						.getObjectId(),prefix, keepOriginalId));
 			}
 		}
 

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsTransferProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsTransferProducer.java
@@ -27,12 +27,12 @@ public class GtfsTransferProducer extends AbstractProducer
    }
    private GtfsTransfer transfer = new GtfsTransfer();
 
-   public boolean save(ConnectionLink neptuneObject, String prefix)
+   public boolean save(ConnectionLink neptuneObject, String prefix, boolean keepOriginalId)
    {
       transfer.setFromStopId(toGtfsId(neptuneObject.getStartOfLink()
-            .getObjectId(),prefix));
+            .getObjectId(),prefix,keepOriginalId));
       transfer
-            .setToStopId(toGtfsId(neptuneObject.getEndOfLink().getObjectId(),prefix));
+            .setToStopId(toGtfsId(neptuneObject.getEndOfLink().getObjectId(),prefix, keepOriginalId));
       if (neptuneObject.getDefaultDuration() != null
             && neptuneObject.getDefaultDuration().getTime() > 1000)
       {

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsTripProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsTripProducer.java
@@ -63,7 +63,7 @@ public class GtfsTripProducer extends AbstractProducer {
 	 * @param sharedPrefix
 	 * @return list of stoptimes
 	 */
-	private boolean saveTimes(VehicleJourney vj, String prefix, String sharedPrefix) {
+	private boolean saveTimes(VehicleJourney vj, String prefix, String sharedPrefix, boolean keepOriginalId) {
 		if (vj.getVehicleJourneyAtStops().isEmpty())
 			return false;
 		Line l = vj.getRoute().getLine();
@@ -74,7 +74,7 @@ public class GtfsTripProducer extends AbstractProducer {
 		int departureOffset = 0;
 		int arrivalOffset = 0;
 		
-		String tripId = toGtfsId(vj.getObjectId(), prefix);
+		String tripId = toGtfsId(vj.getObjectId(), prefix, keepOriginalId);
 		time.setTripId(tripId);
 		List<VehicleJourneyAtStop> lvjas = new ArrayList<>(vj.getVehicleJourneyAtStops());
 		Collections.sort(lvjas, new Comparator<VehicleJourneyAtStop>() {
@@ -87,7 +87,7 @@ public class GtfsTripProducer extends AbstractProducer {
 		List<RouteSection> routeSections = vj.getJourneyPattern().getRouteSections();
 		int index = 0;
 		for (VehicleJourneyAtStop vjas : lvjas) {
-			time.setStopId(toGtfsId(vjas.getStopPoint().getContainedInStopArea().getObjectId(), sharedPrefix));
+			time.setStopId(toGtfsId(vjas.getStopPoint().getContainedInStopArea().getObjectId(), sharedPrefix, keepOriginalId));
 			Time arrival = vjas.getArrivalTime();
 			arrivalOffset = vjas.getArrivalDayOffset(); /** GJT */
 			
@@ -233,15 +233,15 @@ public class GtfsTripProducer extends AbstractProducer {
 	 *            vehicle journey with multiple timetables
 	 * @return gtfs trip
 	 */
-	public boolean save(VehicleJourney vj, String serviceId,  String prefix, String sharedPrefix) {
+	public boolean save(VehicleJourney vj, String serviceId,  String prefix, String sharedPrefix, boolean keepOriginalId) {
 
-		String tripId = toGtfsId(vj.getObjectId(), prefix);
+		String tripId = toGtfsId(vj.getObjectId(), prefix, keepOriginalId);
 
 		trip.setTripId(tripId);
 
 		JourneyPattern jp = vj.getJourneyPattern();
 		if (jp.getSectionStatus() == SectionStatusEnum.Completed) {
-			String shapeId = toGtfsId(jp.getObjectId(), prefix);
+			String shapeId = toGtfsId(jp.getObjectId(), prefix, keepOriginalId);
 			trip.setShapeId(shapeId);
 		}
 		else
@@ -250,7 +250,7 @@ public class GtfsTripProducer extends AbstractProducer {
 		}
 		Route route = vj.getRoute();
 		Line line = route.getLine();
-		trip.setRouteId(toGtfsId(line.getObjectId(), prefix));
+		trip.setRouteId(toGtfsId(line.getObjectId(), prefix, keepOriginalId));
 		if ("R".equals(route.getWayBack())) {
 			trip.setDirectionId(GtfsTrip.DirectionType.Inbound);
 		} else {
@@ -284,7 +284,7 @@ public class GtfsTripProducer extends AbstractProducer {
 		// trip.setBikeAllowed();
 
 		// add StopTimes
-		if (saveTimes(vj,  prefix, sharedPrefix)) {
+		if (saveTimes(vj,  prefix, sharedPrefix, keepOriginalId)) {
 			try {
 				getExporter().getTripExporter().export(trip);
 			} catch (Exception e) {

--- a/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportAbstractProducerTests.java
+++ b/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportAbstractProducerTests.java
@@ -22,8 +22,8 @@ public class GtfsExportAbstractProducerTests
    public void verifyToGtfsId() throws ChouetteException
    {
 
-      Assert.assertEquals(producer.toGtfsIdWrapper("GTFS:Type:1234", "GTFS"), "1234", "gtfs id must contains only third part of neptune id");
-      Assert.assertEquals(producer.toGtfsIdWrapper("GTFS:Type:1234", "TEST"), "GTFS.1234",
+      Assert.assertEquals(producer.toGtfsIdWrapper("GTFS:Type:1234", "GTFS",false), "1234", "gtfs id must contains only third part of neptune id");
+      Assert.assertEquals(producer.toGtfsIdWrapper("GTFS:Type:1234", "TEST",false), "GTFS.1234",
             "gtfs id must contains combination of first and third parts of neptune id");
 
    }

--- a/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportAgencyProducerTests.java
+++ b/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportAgencyProducerTests.java
@@ -33,7 +33,7 @@ public class GtfsExportAgencyProducerTests
       neptuneObject.setUrl("http://www.mywebsite.com");
       neptuneObject.setPhone("01 02 03 04 05");
 
-      producer.save(neptuneObject,  "GTFS", null);
+      producer.save(neptuneObject,  "GTFS", null,false);
       GtfsAgency gtfsObject = mock.getExportedAgencies().get(0);
       Reporter.log("verifyAgencyProducer1");
       Reporter.log(AgencyExporter.CONVERTER.to(context, gtfsObject));
@@ -62,7 +62,7 @@ public class GtfsExportAgencyProducerTests
       neptuneObject.setShortName("short");
       neptuneObject.setPhone("01 02 03 04 05");
 
-      producer.save(neptuneObject, "GTFS", null);
+      producer.save(neptuneObject, "GTFS", null,false);
       GtfsAgency gtfsObject = mock.getExportedAgencies().get(0);
       Reporter.log("verifyAgencyProducer2");
       Reporter.log(AgencyExporter.CONVERTER.to(context, gtfsObject));
@@ -91,7 +91,7 @@ public class GtfsExportAgencyProducerTests
       neptuneObject.setName("name");
       neptuneObject.setPhone("01 02 03 04 05");
 
-      producer.save(neptuneObject, "GTFS", null);
+      producer.save(neptuneObject, "GTFS", null,false);
       GtfsAgency gtfsObject = mock.getExportedAgencies().get(0);
       Reporter.log("verifyAgencyProducer3");
       Reporter.log(AgencyExporter.CONVERTER.to(context, gtfsObject));
@@ -119,7 +119,7 @@ public class GtfsExportAgencyProducerTests
       neptuneObject.setName("name");
 
       Reporter.log("verifyAgencyProducer4");
-      producer.save(neptuneObject,  "GTFS", TimeZone.getTimeZone("America/Montreal"));
+      producer.save(neptuneObject,  "GTFS", TimeZone.getTimeZone("America/Montreal"),false);
       GtfsAgency gtfsObject = mock.getExportedAgencies().get(0);
       Reporter.log(AgencyExporter.CONVERTER.to(context, gtfsObject));
 
@@ -128,7 +128,7 @@ public class GtfsExportAgencyProducerTests
       
       neptuneObject.setTimeZone("Europe/Paris");
       mock.reset();
-      producer.save(neptuneObject, "GTFS", TimeZone.getTimeZone("America/Montreal"));
+      producer.save(neptuneObject, "GTFS", TimeZone.getTimeZone("America/Montreal"),false);
       gtfsObject = mock.getExportedAgencies().get(0);
       Reporter.log(AgencyExporter.CONVERTER.to(context, gtfsObject));
       Assert.assertEquals(gtfsObject.getAgencyTimezone().getID(),"Europe/Paris" ,

--- a/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportCalendarProducerTests.java
+++ b/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportCalendarProducerTests.java
@@ -52,7 +52,7 @@ public class GtfsExportCalendarProducerTests
 
       List<Timetable> tms = new ArrayList<>();
       tms.add(neptuneObject);
-      producer.save(tms,  "GTFS");
+      producer.save(tms,  "GTFS",false);
       Reporter.log("verifyCalendarProducer1");
       Assert.assertEquals(mock.getExportedCalendars().size(),1,"Calendar must be returned");
       GtfsCalendar gtfsObject = mock.getExportedCalendars().get(0);
@@ -94,7 +94,7 @@ public class GtfsExportCalendarProducerTests
 
       List<Timetable> tms = new ArrayList<>();
       tms.add(neptuneObject);
-      producer.save(tms,  "GTFS");
+      producer.save(tms,  "GTFS",false);
       Reporter.log("verifyCalendarProducer2");
 
       Assert.assertEquals(mock.getExportedCalendars().size(), 0, "no calendar produced");
@@ -148,7 +148,7 @@ public class GtfsExportCalendarProducerTests
 
       List<Timetable> tms = new ArrayList<>();
       tms.add(neptuneObject);
-      producer.save(tms,  "GTFS");
+      producer.save(tms,  "GTFS",false);
       Reporter.log("verifyCalendarProducer3");
       Assert.assertEquals(mock.getExportedCalendars().size(),1,"Calendar must be returned");
       GtfsCalendar gtfsObject = mock.getExportedCalendars().get(0);
@@ -214,7 +214,7 @@ public class GtfsExportCalendarProducerTests
 
       List<Timetable> tms = new ArrayList<>();
       tms.add(neptuneObject);
-      producer.save(tms,  "GTFS");
+      producer.save(tms,  "GTFS",false);
       Reporter.log("verifyCalendarProducer4");
 
       Assert.assertEquals(mock.getExportedCalendars().size(), 0, "no calendar produced");

--- a/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportExtendedStopProducerTests.java
+++ b/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportExtendedStopProducerTests.java
@@ -56,7 +56,7 @@ public class GtfsExportExtendedStopProducerTests
       parents.add(parent);
       neptuneObject.setParent(parent);
 
-      producer.save(neptuneObject,  "GTFS", parents);
+      producer.save(neptuneObject,  "GTFS", parents,false);
       GtfsStop gtfsObject = mock.getExportedStops().get(0);
       Reporter.log("verifyExtendedStopProducerWithFullData");
       Reporter.log(StopExtendedExporter.CONVERTER.to(context, gtfsObject));

--- a/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportRouteProducerTests.java
+++ b/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportRouteProducerTests.java
@@ -38,7 +38,7 @@ public class GtfsExportRouteProducerTests
       company.setName("name");
       neptuneObject.setCompany(company);
 
-      producer.save(neptuneObject, "GTFS");
+      producer.save(neptuneObject, "GTFS",false);
       Reporter.log("verifyRouteProducerWithShortAndLongName");
       Assert.assertEquals(mock.getExportedRoutes().size(), 1, "Route should be returned");
       GtfsRoute gtfsObject = mock.getExportedRoutes().get(0);
@@ -69,7 +69,7 @@ public class GtfsExportRouteProducerTests
       company.setObjectId("GTFS:Company:1234");
       company.setName("name");
       neptuneObject.setCompany(company);
-      producer.save(neptuneObject,"GTFS");
+      producer.save(neptuneObject,"GTFS",false);
       Reporter.log("verifyRouteProducerWithNoShortName");
       Assert.assertEquals(mock.getExportedRoutes().size(), 1, "Route should be returned");
       GtfsRoute gtfsObject = mock.getExportedRoutes().get(0);
@@ -95,7 +95,7 @@ public class GtfsExportRouteProducerTests
       company.setObjectId("GTFS:Company:1234");
       company.setName("name");
       neptuneObject.setCompany(company);
-      producer.save(neptuneObject,  "GTFS");
+      producer.save(neptuneObject,  "GTFS",false);
       Reporter.log("verifyRouteProducerWithNoLongName");
       Assert.assertEquals(mock.getExportedRoutes().size(), 1, "Route should be returned");
       GtfsRoute gtfsObject = mock.getExportedRoutes().get(0);
@@ -117,7 +117,7 @@ public class GtfsExportRouteProducerTests
       company.setObjectId("GTFS:Company:1234");
       company.setName("name");
       neptuneObject.setCompany(company);
-      boolean state = producer.save(neptuneObject, "GTFS");
+      boolean state = producer.save(neptuneObject, "GTFS",false);
       Reporter.log("verifyRouteProducerWithNoName");
       Assert.assertFalse(state, "GTFS Route must not be produced");
 

--- a/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportStopProducerTests.java
+++ b/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportStopProducerTests.java
@@ -49,7 +49,7 @@ public class GtfsExportStopProducerTests
       parents.add(parent);
       neptuneObject.setParent(parent);
 
-      producer.save(neptuneObject,  "GTFS", parents);
+      producer.save(neptuneObject,  "GTFS", parents,false);
       GtfsStop gtfsObject = mock.getExportedStops().get(0);
       Reporter.log("verifyStopProducerStopWithFullData");
       Reporter.log(StopExporter.CONVERTER.to(context, gtfsObject));
@@ -91,7 +91,7 @@ public class GtfsExportStopProducerTests
       List<StopArea> parents = new ArrayList<>();
       parents.add(parent);
 
-      producer.save(neptuneObject,  "GTFS", parents);
+      producer.save(neptuneObject,  "GTFS", parents,false);
       GtfsStop gtfsObject = mock.getExportedStops().get(0);
       Reporter.log("verifyStopProducerStopWithLessData");
       Reporter.log(StopExporter.CONVERTER.to(context, gtfsObject));
@@ -137,7 +137,7 @@ public class GtfsExportStopProducerTests
       parents.add(parent);
       neptuneObject.setParent(parent);
 
-      producer.save(neptuneObject, "GTFS", parents);
+      producer.save(neptuneObject, "GTFS", parents,false);
       GtfsStop gtfsObject = mock.getExportedStops().get(0);
       Reporter.log("verifyStopProducerStationWithFullData");
       Reporter.log(StopExporter.CONVERTER.to(context, gtfsObject));
@@ -181,7 +181,7 @@ public class GtfsExportStopProducerTests
 
       List<StopArea> parents = new ArrayList<>();
 
-      Assert.assertFalse(producer.save(neptuneObject, "GTFS", parents));
+      Assert.assertFalse(producer.save(neptuneObject, "GTFS", parents,false));
 
    }
 

--- a/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportTransferProducerTests.java
+++ b/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportTransferProducerTests.java
@@ -39,7 +39,7 @@ public class GtfsExportTransferProducerTests
       Time defaultDuration = new Time(60000);
       neptuneObject.setDefaultDuration(defaultDuration);
 
-      producer.save(neptuneObject,  "GTFS");
+      producer.save(neptuneObject,  "GTFS",false);
       GtfsTransfer gtfsObject = mock.getExportedTransfers().get(0);
       Reporter.log("verifyTransferProducer1");
       Reporter.log(TransferExporter.CONVERTER.to(context,gtfsObject));
@@ -69,7 +69,7 @@ public class GtfsExportTransferProducerTests
       Time defaultDuration = new Time(500);
       neptuneObject.setDefaultDuration(defaultDuration);
 
-      producer.save(neptuneObject, "GTFS");
+      producer.save(neptuneObject, "GTFS",false);
       GtfsTransfer gtfsObject = mock.getExportedTransfers().get(0);
       Reporter.log("verifyTransferProducer2");
       Reporter.log(TransferExporter.CONVERTER.to(context,gtfsObject));

--- a/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportTripProducerTests.java
+++ b/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsExportTripProducerTests.java
@@ -37,7 +37,7 @@ public class GtfsExportTripProducerTests
 
       VehicleJourney neptuneObject = buildNeptuneObject(true);
 
-      producer.save(neptuneObject, "tm_01", "GTFS", "GTFS");
+      producer.save(neptuneObject, "tm_01", "GTFS", "GTFS",false);
       Reporter.log("verifyTripProducerWithFullData");
 
       Assert.assertEquals(mock.getExportedTrips().size(), 1, "Trip should be returned");
@@ -103,7 +103,7 @@ public class GtfsExportTripProducerTests
 
       VehicleJourney neptuneObject = buildNeptuneObject(false);
 
-      producer.save(neptuneObject, "tm_01", "GTFS", "GTFS");
+      producer.save(neptuneObject, "tm_01", "GTFS", "GTFS",false);
       Reporter.log("verifyTripProducerWithLessData");
 
       Assert.assertEquals(mock.getExportedTrips().size(), 1, "Trip should be returned");
@@ -170,7 +170,7 @@ public class GtfsExportTripProducerTests
       VehicleJourney neptuneObject = buildNeptuneObject(true);
       neptuneObject.setMobilityRestrictedSuitability(Boolean.TRUE);
 
-      producer.save(neptuneObject, "tm_01",  "GTFS", "GTFS");
+      producer.save(neptuneObject, "tm_01",  "GTFS", "GTFS",false);
 
       Assert.assertEquals(mock.getExportedTrips().size(), 1, "Trip should be returned");
       GtfsTrip gtfsObject = mock.getExportedTrips().get(0);
@@ -179,7 +179,7 @@ public class GtfsExportTripProducerTests
 
       mock.reset();
       neptuneObject.setMobilityRestrictedSuitability(Boolean.FALSE);
-      producer.save(neptuneObject, "tm_01", "GTFS", "GTFS");
+      producer.save(neptuneObject, "tm_01", "GTFS", "GTFS",false);
       Assert.assertEquals(mock.getExportedTrips().size(), 1, "Trip should be returned");
       gtfsObject = mock.getExportedTrips().get(0);
       Reporter.log(TripExporter.CONVERTER.to(context,gtfsObject));
@@ -187,7 +187,7 @@ public class GtfsExportTripProducerTests
 
       mock.reset();
       neptuneObject.setMobilityRestrictedSuitability(null);
-      producer.save(neptuneObject, "tm_01",  "GTFS", "GTFS");
+      producer.save(neptuneObject, "tm_01",  "GTFS", "GTFS",false);
       Assert.assertEquals(mock.getExportedTrips().size(), 1, "Trip should be returned");
       gtfsObject = mock.getExportedTrips().get(0);
       Reporter.log(TripExporter.CONVERTER.to(context,gtfsObject));
@@ -204,7 +204,7 @@ public class GtfsExportTripProducerTests
       VehicleJourney neptuneObject = buildNeptuneObject(true);
       Route r = neptuneObject.getRoute();
       r.setWayBack("A");
-      producer.save(neptuneObject, "tm_01", "GTFS", "GTFS");
+      producer.save(neptuneObject, "tm_01", "GTFS", "GTFS",false);
 
       Assert.assertEquals(mock.getExportedTrips().size(), 1, "Trip should be returned");
       GtfsTrip gtfsObject = mock.getExportedTrips().get(0);
@@ -212,14 +212,14 @@ public class GtfsExportTripProducerTests
 
       mock.reset();
       r.setWayBack("R");
-      producer.save(neptuneObject, "tm_01",  "GTFS", "GTFS");
+      producer.save(neptuneObject, "tm_01",  "GTFS", "GTFS",false);
       Assert.assertEquals(mock.getExportedTrips().size(), 1, "Trip should be returned");
       gtfsObject = mock.getExportedTrips().get(0);
       Assert.assertEquals(gtfsObject.getDirectionId(), DirectionType.Inbound, "DirectionId must be correctly set");
 
       mock.reset();
       r.setWayBack(null);
-      producer.save(neptuneObject, "tm_01",  "GTFS", "GTFS");
+      producer.save(neptuneObject, "tm_01",  "GTFS", "GTFS",false);
       Assert.assertEquals(mock.getExportedTrips().size(), 1, "Trip should be returned");
       gtfsObject = mock.getExportedTrips().get(0);
       Assert.assertEquals(gtfsObject.getDirectionId(), DirectionType.Outbound, "DirectionId must be correctly set");

--- a/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/mock/GtfsDummyProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/exporter/producer/mock/GtfsDummyProducer.java
@@ -15,9 +15,9 @@ public class GtfsDummyProducer extends AbstractProducer
       super(exporter);
    }
    
-   public String toGtfsIdWrapper(String neptuneId, String prefix)
+   public String toGtfsIdWrapper(String neptuneId, String prefix, boolean keepOriginalId)
    {
-      return toGtfsId(neptuneId, prefix);
+      return toGtfsId(neptuneId, prefix, keepOriginalId);
    }
    
    public Color getColorWrapper(String color)


### PR DESCRIPTION
Currently all entity identifiers in the exported GTFS file are rewritten on export. Ie 'XYZ:StopArea:123' becomes stop_id '123'.

This PR adds an export parameter and support for exporting the original objectId.

Defaults to original behaviour.