### PR TITLE
Fix invalid calendars when merging timetables

### DIFF
--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/AbstractProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/AbstractProducer.java
@@ -22,7 +22,7 @@ public abstract class AbstractProducer
    static protected String toGtfsId(String neptuneId, String prefix, boolean keepOriginal)
    {
       if(keepOriginal) {
-    	  return neptuneId.replace(':', '.');
+    	  return neptuneId;
       } else {
     	  String[] tokens = neptuneId.split(":");
 	      if (tokens[0].equals(prefix))

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsServiceProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsServiceProducer.java
@@ -263,7 +263,11 @@ AbstractProducer
 			}
             
          }
-         merged.setObjectId(prefix+":"+Timetable.TIMETABLE_KEY+":"+key(timetables,prefix,false));
+         if(keepOriginalId) {
+             merged.setObjectId(key(timetables,prefix,true));
+         } else {
+             merged.setObjectId(prefix+":"+Timetable.TIMETABLE_KEY+":"+key(timetables,prefix,false));
+         }
       }
       merged.computeLimitOfPeriods();
       return merged;

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsServiceProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsServiceProducer.java
@@ -289,11 +289,28 @@ AbstractProducer
 
       Collections.sort(timetables, new TimetableSorter());
       String key = "";
-      for (Timetable timetable : timetables)
-      {
-         key += "-"+toGtfsId(timetable.getObjectId(), prefix, keepOriginalId);
+      
+      if(keepOriginalId) {
+          for(int i = 0;i<timetables.size();i++) {
+        	  if(i ==0) {
+        		  // Keep full id
+                  key += toGtfsId(timetables.get(i).getObjectId(), prefix, true);
+        	  } else {
+        		  // Only keep remaining parts
+                  key += "-"+toGtfsId(timetables.get(i).getObjectId(), prefix, false);
+        	  }
+          }
+    	  
+      } else {
+          for (Timetable timetable : timetables)
+          {
+             key += "-"+toGtfsId(timetable.getObjectId(), prefix, keepOriginalId);
+          }
+          // Trim leading dash
+          key = key.substring(1);
       }
-      return key.substring(1);
+      
+      return key;
    }
 
    private class TimetableSorter implements Comparator<Timetable>


### PR DESCRIPTION
The choice to keep the original id when exporting GTFS data (instead of stripping prefix and object type) has a problem when merging different timetables. This PR fixes this