### PR TITLE
Parse GTFS alighting and boarding information

### DIFF
--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsTripProducer.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/exporter/producer/GtfsTripProducer.java
@@ -153,6 +153,8 @@ public class GtfsTripProducer extends AbstractProducer {
 
 	private void addDropOffAndPickUpType(GtfsStopTime time, Line l, VehicleJourney vj, VehicleJourneyAtStop vjas) {
 
+		time.setPickupType(null);
+		time.setDropOffType(null);
 		boolean routeOnDemand = isTrue(l.getFlexibleService());
 		boolean tripOnDemand = false;
 		if (routeOnDemand) {

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsTripParser.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsTripParser.java
@@ -867,7 +867,7 @@ public class GtfsTripParser implements Parser, Validator, Constant {
 	
 	private BoardingPossibilityEnum toBoardingPossibility(PickupType type) {
 		if(type == null) {
-			return null;
+			return BoardingPossibilityEnum.normal;
 		}
 		
 		switch (type) {
@@ -885,7 +885,7 @@ public class GtfsTripParser implements Parser, Validator, Constant {
 
 	private AlightingPossibilityEnum toAlightingPossibility(DropOffType type) {
 		if(type == null) {
-			return null;
+			return AlightingPossibilityEnum.normal;
 		}
 		
 		switch (type) {


### PR DESCRIPTION
Currently for GTFS files boarding and alighting information is not parsed. This PR adds this functionality.

The code creates multiple journey patterns if boarding and and alighting info differs on various trips for the given line