### PR TITLE
Never truncate objectIds, information is lost and can cause duplicate…

### DIFF
--- a/mobi.chouette.model/src/main/java/mobi/chouette/model/NeptuneIdentifiedObject.java
+++ b/mobi.chouette.model/src/main/java/mobi/chouette/model/NeptuneIdentifiedObject.java
@@ -53,7 +53,8 @@ public abstract class NeptuneIdentifiedObject extends NeptuneObject implements
 	protected String objectId;
 
 	public void setObjectId(String value) {
-		objectId = StringUtils.abbreviate(value, 255);
+		// Do not abbreviate objectIds, it causes information to be lost on ie exports and leads to duplicate data
+		objectId = value;
 	}
 
 	/**


### PR DESCRIPTION
… ids when ie exporting data and merging ids for better compression.

Maximum length on objectids should be handled in the user interface or by throwing exceptions if too long. Currently they are silently truncated to 255 characters causing strange errors further down the line.