### PR TITLE
Allow querying for job status for all referentials in a single request

### DIFF
--- a/mobi.chouette.dao.iev/src/main/java/mobi/chouette/dao/iev/JobDAO.java
+++ b/mobi.chouette.dao.iev/src/main/java/mobi/chouette/dao/iev/JobDAO.java
@@ -1,5 +1,6 @@
 package mobi.chouette.dao.iev;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -47,10 +48,17 @@ public class JobDAO extends GenericDAOImpl<Job> {
 		if(status.length != 0) {
 			 statusPredicate = root.get(Job_.status).in(Arrays.asList(status));
 		}
-		
-		Predicate referentialPredicate = builder.equal(root.get(Job_.referential),
-				referential);
-		criteria.where(builder.and( referentialPredicate, statusPredicate));
+		List<Predicate> predicates = new ArrayList<>();
+		predicates.add(statusPredicate);
+
+		if (referential != null) {
+			Predicate referentialPredicate = builder.equal(root.get(Job_.referential),
+					referential);
+			predicates.add(referentialPredicate);
+		}
+
+		criteria.where(builder.and(predicates.toArray(new Predicate[predicates.size()])));
+
 		criteria.orderBy(builder.asc(root.get(Job_.created)));
 		TypedQuery<Job> query = em.createQuery(criteria);
 		result = query.getResultList();
@@ -71,15 +79,23 @@ public class JobDAO extends GenericDAOImpl<Job> {
 		if(status.length != 0) {
 			 statusPredicate = root.get(Job_.status).in(Arrays.asList(status));
 		}
-		Predicate referentialPredicate = builder.equal(root.get(Job_.referential),
-				referential);
 
-		if(action.length != 0) {
-			Predicate actionPredicate = root.get(Job_.action).in(Arrays.asList(action)); 
-			criteria.where( builder.and(referentialPredicate, actionPredicate,statusPredicate ));
-		} else {
-			criteria.where( builder.and(referentialPredicate, statusPredicate ));
+		List<Predicate> predicates = new ArrayList<>();
+		predicates.add(statusPredicate);
+
+		if (action.length != 0) {
+			Predicate actionPredicate = root.get(Job_.action).in(Arrays.asList(action));
+			predicates.add(actionPredicate);
 		}
+
+		if (referential != null) {
+			Predicate referentialPredicate = builder.equal(root.get(Job_.referential),
+					referential);
+			predicates.add(referentialPredicate);
+		}
+
+		criteria.where(builder.and(predicates.toArray(new Predicate[predicates.size()])));
+
 		criteria.orderBy(builder.asc(root.get(Job_.created)));
 		TypedQuery<Job> query = em.createQuery(criteria);
 		result = query.getResultList();

--- a/mobi.chouette.service/src/main/java/mobi/chouette/service/JobServiceManager.java
+++ b/mobi.chouette.service/src/main/java/mobi/chouette/service/JobServiceManager.java
@@ -451,8 +451,9 @@ public class JobServiceManager {
 	}
 
 	public List<JobService> jobs(String referential, String action[], final Long version, Job.STATUS[] status) throws ServiceException {
-		validateReferential(referential);
-
+		if (referential!=null) {
+			validateReferential(referential);
+		}
 		List<Job> jobs = null;
 		if (action == null) {
 			jobs = jobDAO.findByReferential(referential,status);

--- a/mobi.chouette.ws/src/main/java/mobi/chouette/ws/JobInfo.java
+++ b/mobi.chouette.ws/src/main/java/mobi/chouette/ws/JobInfo.java
@@ -30,8 +30,8 @@ import mobi.chouette.service.ServiceException;
 @NoArgsConstructor
 @XmlRootElement(name = "job")
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { "id", "referential", "action", "type", "created", "started", "updated", "status", "linkInfos",
-		"actionParameters" })
+@XmlType(propOrder = {"id", "referential", "action", "type", "created", "started", "updated", "status", "linkInfos",
+		                     "actionParameters"})
 // @XmlSeeAlso({NeptuneImportParameters.class,
 // NeptuneExportParameters.class,
 // GtfsImportParameters.class,
@@ -80,6 +80,10 @@ public class JobInfo implements ServiceConstants {
 	private AbstractParameter actionParameters;
 
 	public JobInfo(JobService job, boolean addLink, UriInfo uriInfo) throws ServiceException {
+		this(job, addLink, true, uriInfo);
+	}
+
+	public JobInfo(JobService job, boolean addLink, boolean addActionParameters, UriInfo uriInfo) throws ServiceException {
 		id = job.getId();
 		referential = job.getReferential();
 		action = job.getAction();
@@ -89,8 +93,9 @@ public class JobInfo implements ServiceConstants {
 		updated = job.getUpdated();
 		status = STATUS.valueOf(job.getStatus().name());
 
-		actionParameters = job.getActionParameter();
-
+		if (addActionParameters) {
+			actionParameters = job.getActionParameter();
+		}
 		if (addLink) {
 			linkInfos = new ArrayList<>();
 			for (Link link : job.getJob().getLinks()) {

--- a/mobi.chouette.ws/src/main/java/mobi/chouette/ws/RestService.java
+++ b/mobi.chouette.ws/src/main/java/mobi/chouette/ws/RestService.java
@@ -265,8 +265,9 @@ public class RestService implements Constant {
 			@DefaultValue("0") @QueryParam("version") final Long version, @QueryParam("action") final String[] action, @QueryParam("status") final Job.STATUS[] status) {
 
 		try {
-			log.info(Color.CYAN + "Call jobs referential = " + referential + ", action = " + StringUtils.join(action,',')+", status = " + StringUtils.join(status,',') + ", version = "
-					+ version + Color.NORMAL);
+			String refDescription = referential == null ? "all referentials" : "referential = " + referential;
+			log.info(Color.CYAN + "Call jobs = " + refDescription + ", action = " + StringUtils.join(action, ',') + ", status = " + StringUtils.join(status, ',') + ", version = "
+					         + version + Color.NORMAL);
 
 			// create jobs listing
 			List<JobInfo> result = new ArrayList<>();
@@ -298,6 +299,14 @@ public class RestService implements Constant {
 			log.error(ex.getMessage(), ex);
 			throw new WebApplicationException("INTERNAL_ERROR", Status.INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	// jobs listing for all referentials
+	@GET
+	@Path("/jobs")
+	@Produces({MediaType.APPLICATION_JSON})
+	public Response jobs(@DefaultValue("0") @QueryParam("version") final Long version, @QueryParam("action") final String[] action, @QueryParam("status") final Job.STATUS[] status) {
+		return jobs(null, version, action, status);
 	}
 
 	// view scheduled job

--- a/mobi.chouette.ws/src/main/java/mobi/chouette/ws/RestService.java
+++ b/mobi.chouette.ws/src/main/java/mobi/chouette/ws/RestService.java
@@ -262,7 +262,8 @@ public class RestService implements Constant {
 	@Path("/{ref}/jobs")
 	@Produces({ MediaType.APPLICATION_JSON })
 	public Response jobs(@PathParam("ref") String referential,
-			@DefaultValue("0") @QueryParam("version") final Long version, @QueryParam("action") final String[] action, @QueryParam("status") final Job.STATUS[] status) {
+			@DefaultValue("0") @QueryParam("version") final Long version, @QueryParam("action") final String[] action,
+			                        @QueryParam("status") final Job.STATUS[] status, @DefaultValue("true") @QueryParam("addActionParameters") boolean addActionParameters) {
 
 		try {
 			String refDescription = referential == null ? "all referentials" : "referential = " + referential;
@@ -276,7 +277,7 @@ public class RestService implements Constant {
 			{
 				List<JobService> jobServices = jobServiceManager.jobs(referential, action, version,status);
 				for (JobService jobService : jobServices) {
-					JobInfo jobInfo = new JobInfo(jobService, true, uriInfo);
+					JobInfo jobInfo = new JobInfo(jobService, true,addActionParameters, uriInfo);
 					result.add(jobInfo);
 				}
 				jobServices.clear();
@@ -305,8 +306,9 @@ public class RestService implements Constant {
 	@GET
 	@Path("/jobs")
 	@Produces({MediaType.APPLICATION_JSON})
-	public Response jobs(@DefaultValue("0") @QueryParam("version") final Long version, @QueryParam("action") final String[] action, @QueryParam("status") final Job.STATUS[] status) {
-		return jobs(null, version, action, status);
+	public Response jobs(@DefaultValue("0") @QueryParam("version") final Long version, @QueryParam("action") final String[] action,
+			                        @QueryParam("status") final Job.STATUS[] status, @DefaultValue("true") @QueryParam("addActionParameters") boolean addActionParameters) {
+		return jobs(null, version, action, status, addActionParameters);
 	}
 
 	// view scheduled job


### PR DESCRIPTION
Allow clients to fetch job status for all referentials in a single request by using new rest method chouette_iev/referentials/jobs. Made referential optional in existing service & DAO methods used for the corresponding service for fetching job status for a single referential.