### PR TITLE
Added input parameter to disable parsing of GTFS ids in format PREFIX.123

### DIFF
--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/importer/GtfsImportParameters.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/importer/GtfsImportParameters.java
@@ -21,6 +21,7 @@ import org.apache.log4j.Logger;
 @ToString(callSuper=true)
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(propOrder={"objectIdPrefix",
+		"splitIdOnDot",
 		"maxDistanceForConnectionLink",
 		"maxDistanceForCommercial",
 		"ignoreEndChars",

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/importer/GtfsImportParameters.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/importer/GtfsImportParameters.java
@@ -33,6 +33,10 @@ public class GtfsImportParameters extends AbstractImportParameter {
 	private String objectIdPrefix;
 
 	@Getter@Setter
+	@XmlElement(name = "split_id_on_dot", defaultValue="true")
+	private boolean splitIdOnDot = true;
+
+	@Getter@Setter
 	@XmlElement(name = "max_distance_for_connection_link", defaultValue="0")
 	private int maxDistanceForConnectionLink = 0;
 

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/AbstractConverter.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/AbstractConverter.java
@@ -5,6 +5,7 @@ import java.sql.Time;
 import java.util.TimeZone;
 
 import mobi.chouette.common.Constant;
+import mobi.chouette.exchange.gtfs.importer.GtfsImportParameters;
 import mobi.chouette.exchange.gtfs.model.GtfsTime;
 
 import org.apache.log4j.Logger;
@@ -34,16 +35,19 @@ public abstract class AbstractConverter implements Constant{
 		return time;
 	}
 
-	public static String composeObjectId(String prefix, String type, String id, Logger logger) {
+	public static String composeObjectId(GtfsImportParameters configuration, String type, String id, Logger logger) {
 
 		if (id == null || id.isEmpty() ) return "";
-		String[] tokens = id.split("\\.");
-		if (tokens.length == 2) {
-			// id should be produced by Chouette
-			return tokens[0].trim().replaceAll("[^a-zA-Z_0-9]", "_") + ":" + type + ":"
-					+ tokens[1].trim().replaceAll("[^a-zA-Z_0-9\\-]", "_");
+		
+		if(configuration.isSplitIdOnDot()) {
+			String[] tokens = id.split("\\.");
+			if (tokens.length == 2) {
+				// id should be produced by Chouette
+				return tokens[0].trim().replaceAll("[^a-zA-Z_0-9]", "_") + ":" + type + ":"+ tokens[1].trim().replaceAll("[^a-zA-Z_0-9\\-]", "_");
+			}
 		}
-		return prefix + ":" + type + ":" + id.trim().replaceAll("[^a-zA-Z_0-9\\-]", "_");
+		return configuration.getObjectIdPrefix() + ":" + type + ":" + id.trim().replaceAll("[^a-zA-Z_0-9\\-]", "_");
+			
 	}
 
 	public static String toString(URL url) {

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsAgencyParser.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsAgencyParser.java
@@ -102,7 +102,7 @@ public class GtfsAgencyParser implements Parser, Validator, Constant {
 		GtfsImportParameters configuration = (GtfsImportParameters) context.get(CONFIGURATION);
 
 		for (GtfsAgency gtfsAgency : importer.getAgencyById()) {
-			String objectId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(), Company.COMPANY_KEY,
+			String objectId = AbstractConverter.composeObjectId(configuration, Company.COMPANY_KEY,
 					gtfsAgency.getAgencyId(), log);
 			Company company = ObjectFactory.getCompany(referential, objectId);
 			convert(context, gtfsAgency, company);

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsCalendarParser.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsCalendarParser.java
@@ -188,7 +188,7 @@ public class GtfsCalendarParser implements Parser, Validator, Constant {
 		if (importer.hasCalendarImporter()) {
 			for (GtfsCalendar gtfsCalendar : importer.getCalendarByService()) {
 
-				String objectId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(),
+				String objectId = AbstractConverter.composeObjectId(configuration,
 						Timetable.TIMETABLE_KEY, gtfsCalendar.getServiceId(), log);
 				Timetable timetable = ObjectFactory.getTimetable(referential, objectId);
 				convert(context, gtfsCalendar, timetable);
@@ -199,7 +199,7 @@ public class GtfsCalendarParser implements Parser, Validator, Constant {
 
 			for (String serviceId : importer.getCalendarDateByService().keys()) {
 
-				String objectId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(),
+				String objectId = AbstractConverter.composeObjectId(configuration,
 						Timetable.TIMETABLE_KEY, serviceId, log);
 
 				Timetable timetable = referential.getTimetables().get(objectId);

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsRouteParser.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsRouteParser.java
@@ -186,7 +186,7 @@ public class GtfsRouteParser implements Parser, Validator, Constant {
 		Index<GtfsRoute> routes = importer.getRouteById();
 		GtfsRoute gtfsRoute = routes.getValue(gtfsRouteId);
 
-		String lineId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(), Line.LINE_KEY,
+		String lineId = AbstractConverter.composeObjectId(configuration, Line.LINE_KEY,
 				gtfsRouteId, log);
 		Line line = ObjectFactory.getLine(referential, lineId);
 		convert(context, gtfsRoute, line);
@@ -199,7 +199,7 @@ public class GtfsRouteParser implements Parser, Validator, Constant {
 
 		// Company
 		if (gtfsRoute.getAgencyId() != null) {
-			String companyId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(),
+			String companyId = AbstractConverter.composeObjectId(configuration,
 					Company.COMPANY_KEY, gtfsRoute.getAgencyId(), log);
 			Company company = ObjectFactory.getCompany(referential, companyId);
 			line.setCompany(company);

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsStopParser.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsStopParser.java
@@ -113,7 +113,7 @@ public class GtfsStopParser implements Parser, Validator, Constant {
 		for (GtfsStop gtfsStop : importer.getStopById()) {
 			if (gtfsStop.getLocationType() != GtfsStop.LocationType.Access) {
 
-				String objectId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(),
+				String objectId = AbstractConverter.composeObjectId(configuration,
 						StopArea.STOPAREA_KEY, gtfsStop.getStopId(), log);
 
 				StopArea stopArea = ObjectFactory.getStopArea(referential, objectId);
@@ -149,7 +149,7 @@ public class GtfsStopParser implements Parser, Validator, Constant {
 			}
 			stopArea.setAreaType(ChouetteAreaEnum.BoardingPosition);
 			if (gtfsStop.getParentStation() != null) {
-				String parenId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(),
+				String parenId = AbstractConverter.composeObjectId(configuration,
 						StopArea.STOPAREA_KEY, gtfsStop.getParentStation(), log);
 				StopArea parent = ObjectFactory.getStopArea(referential, parenId);
 				stopArea.setParent(parent);

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsTransferParser.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsTransferParser.java
@@ -105,7 +105,7 @@ public class GtfsTransferParser implements Parser, Validator, Constant {
 
 		for (GtfsTransfer gtfsTransfer : importer.getTransferByFromStop()) {
 
-			String objectId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(),
+			String objectId = AbstractConverter.composeObjectId(configuration,
 					ConnectionLink.CONNECTIONLINK_KEY, gtfsTransfer.getFromStopId() + "_" + gtfsTransfer.getToStopId(),
 					log);
 			ConnectionLink connectionLink = ObjectFactory.getConnectionLink(referential, objectId);
@@ -119,10 +119,10 @@ public class GtfsTransferParser implements Parser, Validator, Constant {
 		GtfsImportParameters configuration = (GtfsImportParameters) context.get(CONFIGURATION);
 
 		StopArea startOfLink = ObjectFactory.getStopArea(referential, AbstractConverter.composeObjectId(
-				configuration.getObjectIdPrefix(), StopArea.STOPAREA_KEY, gtfsTransfer.getFromStopId(), log));
+				configuration, StopArea.STOPAREA_KEY, gtfsTransfer.getFromStopId(), log));
 		connectionLink.setStartOfLink(startOfLink);
 		StopArea endOfLink = ObjectFactory.getStopArea(referential, AbstractConverter.composeObjectId(
-				configuration.getObjectIdPrefix(), StopArea.STOPAREA_KEY, gtfsTransfer.getToStopId(), log));
+				configuration, StopArea.STOPAREA_KEY, gtfsTransfer.getToStopId(), log));
 		connectionLink.setEndOfLink(endOfLink);
 		connectionLink.setCreationTime(Calendar.getInstance().getTime());
 		connectionLink.setLinkType(ConnectionLinkTypeEnum.Overground);

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsTripParser.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/parser/GtfsTripParser.java
@@ -511,7 +511,7 @@ public class GtfsTripParser implements Parser, Validator, Constant {
 			if (!hasTimes)
 				continue;
 
-			String objectId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(),
+			String objectId = AbstractConverter.composeObjectId(configuration,
 					VehicleJourney.VEHICLEJOURNEY_KEY, gtfsTrip.getTripId(), log);
 			VehicleJourney vehicleJourney = ObjectFactory.getVehicleJourney(referential, objectId);
 			convert(context, gtfsTrip, vehicleJourney);
@@ -537,7 +537,7 @@ public class GtfsTripParser implements Parser, Validator, Constant {
 			Collections.sort(vehicleJourney.getVehicleJourneyAtStops(), VEHICLE_JOURNEY_AT_STOP_COMPARATOR);
 
 			// Timetable
-			String timetableId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(),
+			String timetableId = AbstractConverter.composeObjectId(configuration,
 					Timetable.TIMETABLE_KEY, gtfsTrip.getServiceId(), log);
 			if (afterMidnight) {
 				timetableId += GtfsCalendarParser.AFTER_MIDNIGHT_SUFFIX;
@@ -588,7 +588,7 @@ public class GtfsTripParser implements Parser, Validator, Constant {
 		for (GtfsFrequency frequency : importer.getFrequencyByTrip().values(gtfsTrip.getTripId())) {
 			vehicleJourney.setJourneyCategory(JourneyCategoryEnum.Frequency);
 
-			String timeBandObjectId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(),
+			String timeBandObjectId = AbstractConverter.composeObjectId(configuration,
 					Timeband.TIMETABLE_KEY, gtfsTrip.getTripId() + "-" + count++, log);
 			Timeband timeband = ObjectFactory.getTimeband(referential, timeBandObjectId);
 			timeband.setName(getTimebandName(frequency));
@@ -813,14 +813,14 @@ public class GtfsTripParser implements Parser, Validator, Constant {
 	 * @return
 	 */
 	private Route createRoute(Referential referential, GtfsImportParameters configuration, GtfsTrip gtfsTrip) {
-		String lineId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(), Line.LINE_KEY,
+		String lineId = AbstractConverter.composeObjectId(configuration, Line.LINE_KEY,
 				gtfsTrip.getRouteId(), log);
 		Line line = ObjectFactory.getLine(referential, lineId);
 		String routeKey = gtfsTrip.getRouteId() + "_" + gtfsTrip.getDirectionId().ordinal();
 		if (gtfsTrip.getShapeId() != null && !gtfsTrip.getShapeId().isEmpty())
 			routeKey += "_" + gtfsTrip.getShapeId();
 		routeKey += "_" + line.getRoutes().size();
-		String routeId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(), Route.ROUTE_KEY,
+		String routeId = AbstractConverter.composeObjectId(configuration, Route.ROUTE_KEY,
 				routeKey, log);
 
 		Route route = ObjectFactory.getRoute(referential, routeId);
@@ -910,7 +910,7 @@ public class GtfsTripParser implements Parser, Validator, Constant {
 
 			StopPoint stopPoint = ObjectFactory.getStopPoint(referential, stopKey);
 
-			String stopAreaId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(),
+			String stopAreaId = AbstractConverter.composeObjectId(configuration,
 					StopArea.STOPAREA_KEY, wrapper.stopId, log);
 			StopArea stopArea = ObjectFactory.getStopArea(referential, stopAreaId);
 			stopPoint.setContainedInStopArea(stopArea);

--- a/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/validation/GtfsValidationReporter.java
+++ b/mobi.chouette.exchange.gtfs/src/main/java/mobi/chouette/exchange/gtfs/validation/GtfsValidationReporter.java
@@ -97,7 +97,7 @@ public class GtfsValidationReporter implements Constant {
 			if (gtfsRouteId != null)
 			{
 				GtfsImportParameters configuration = (GtfsImportParameters) context.get(CONFIGURATION);
-				String lineId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(), Line.LINE_KEY,
+				String lineId = AbstractConverter.composeObjectId(configuration, Line.LINE_KEY,
 						gtfsRouteId, log);
 			    loc.getPath().add(loc.new Path(Line.class.getSimpleName(),lineId));
 			}
@@ -117,7 +117,7 @@ public class GtfsValidationReporter implements Constant {
 			if (gtfsRouteId != null)
 			{
 				GtfsImportParameters configuration = (GtfsImportParameters) context.get(CONFIGURATION);
-				String lineId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(), Line.LINE_KEY,
+				String lineId = AbstractConverter.composeObjectId(configuration, Line.LINE_KEY,
 						gtfsRouteId, log);
 			    loc.getPath().add(loc.new Path(Line.class.getSimpleName(),lineId));	
 			}
@@ -133,7 +133,7 @@ public class GtfsValidationReporter implements Constant {
 			if (gtfsRouteId != null)
 			{
 				GtfsImportParameters configuration = (GtfsImportParameters) context.get(CONFIGURATION);
-				String lineId = AbstractConverter.composeObjectId(configuration.getObjectIdPrefix(), Line.LINE_KEY,
+				String lineId = AbstractConverter.composeObjectId(configuration, Line.LINE_KEY,
 						gtfsRouteId, log);
 			    loc.getPath().add(loc.new Path(Line.class.getSimpleName(),lineId));	
 			}

--- a/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/parser/AbstractConverterTest.java
+++ b/mobi.chouette.exchange.gtfs/src/test/java/mobi/chouette/exchange/gtfs/parser/AbstractConverterTest.java
@@ -1,0 +1,27 @@
+package mobi.chouette.exchange.gtfs.parser;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import mobi.chouette.exchange.gtfs.importer.GtfsImportParameters;
+
+public class AbstractConverterTest {
+	@Test
+	public void testCreateIdWithParsingDots() {
+		GtfsImportParameters configuration = new GtfsImportParameters();
+		configuration.setObjectIdPrefix("PRE");
+		String id = AbstractConverter.composeObjectId(configuration, "VehicleJourney", "ABC.123", null);
+	
+		Assert.assertEquals(id, "ABC:VehicleJourney:123");
+	}
+
+	@Test
+	public void testCreateIdWithoutParsingDots() {
+		GtfsImportParameters configuration = new GtfsImportParameters();
+		configuration.setSplitIdOnDot(false);
+		configuration.setObjectIdPrefix("PRE");
+		String id = AbstractConverter.composeObjectId(configuration, "VehicleJourney", "ABC.TestType.123", null);
+	
+		Assert.assertEquals(id, "PRE:VehicleJourney:ABC_TestType_123");
+	}
+}


### PR DESCRIPTION
Currently there is some custom parsing of gtfs id fields. If the id field is on the format PREFIX.123, the prefix is kept instead of using the one in the input parameters.

This PR adds a parameter in GTFSImportParameters to disable this behaviour. 

Defaults to current functionality.